### PR TITLE
interactive needs to handle getInteractiveState

### DIFF
--- a/js/components/app.js
+++ b/js/components/app.js
@@ -88,7 +88,12 @@ export default class App extends PureComponent {
   }
 
   getInteractiveState(data) {
-    this.phone.post('interactiveState', this.state.interactiveState);
+    // "nochange" is a special value supported by LARA which means the state hasn't changed
+    var interactiveState = "nochange";
+    if(this._currentInteractiveState) {
+      interactiveState = this._currentInteractiveState;
+    }
+    this.phone.post('interactiveState', interactiveState);
   }
 
   handleAuthoredStateChange(state) {
@@ -96,7 +101,7 @@ export default class App extends PureComponent {
   }
 
   handleInteractiveStateChange(state) {
-    this.state.interactiveState = state;
+    this._currentInteractiveState = state;
     this.phone.post('interactiveState', state);
   }
 

--- a/js/components/app.js
+++ b/js/components/app.js
@@ -53,6 +53,7 @@ export default class App extends PureComponent {
       interactiveState: DEFAULT_INTERACTIVE_STATE
     };
     this.initInteractive = this.initInteractive.bind(this);
+    this.getInteractiveState = this.getInteractiveState.bind(this);
     this.handleAuthoredStateChange = this.handleAuthoredStateChange.bind(this);
     this.handleInteractiveStateChange = this.handleInteractiveStateChange.bind(this);
   }
@@ -61,6 +62,7 @@ export default class App extends PureComponent {
     Shutterbug.enable();
     this.phone = iframePhone.getIFrameEndpoint();
     this.phone.addListener('initInteractive', this.initInteractive);
+    this.phone.addListener('getInteractiveState', this.getInteractiveState);
     // Initialize connection after all message listeners are added!
     this.phone.initialize();
   }
@@ -85,11 +87,16 @@ export default class App extends PureComponent {
     });
   }
 
+  getInteractiveState(data) {
+    this.phone.post('interactiveState', this.state.interactiveState);
+  }
+
   handleAuthoredStateChange(state) {
     this.phone.post('authoredState', state);
   }
 
   handleInteractiveStateChange(state) {
+    this.state.interactiveState = state;
     this.phone.post('interactiveState', state);
   }
 


### PR DESCRIPTION
LARA sends this message to the interactive before changing pages
if the interactive doesn’t respond then page is never changed
[#133619761]

@pjanik I tested this locally and it seems to be working. I'm not sure though about updating `this.state.interactiveState` is that the right way to do this? Or should it pull the state out of the child?