### PR TITLE
Add support of "report" mode

### DIFF
--- a/js/components/app.js
+++ b/js/components/app.js
@@ -109,6 +109,7 @@ export default class App extends PureComponent {
 
   render() {
     const { mode, authoredState, interactiveState } = this.state;
+    const readOnly = mode === 'report';
     return (
       <div>
         {mode === null && <p>Waiting for iframe-phone initInteractive call...</p>}
@@ -117,7 +118,7 @@ export default class App extends PureComponent {
                      onAuthoredStateChange={this.handleAuthoredStateChange}/>
         }
         {(mode === 'runtime' || mode === 'report') &&
-          <Runtime authoredState={authoredState} initialInteractiveState={interactiveState}
+          <Runtime authoredState={authoredState} initialInteractiveState={interactiveState} readOnly={readOnly}
                    onInteractiveStateChange={this.handleInteractiveStateChange}/>}
       </div>
     );

--- a/js/components/app.js
+++ b/js/components/app.js
@@ -73,10 +73,12 @@ export default class App extends PureComponent {
   }
 
   initInteractive(data) {
+    const authoredState = typeof data.authoredState === 'string' ? JSON.parse(data.authoredState) : data.authoredState;
+    const interactiveState = typeof data.interactiveState === 'string' ? JSON.parse(data.interactiveState) : data.interactiveState;
     this.setState({
       mode: data.mode,
-      authoredState: data.authoredState || DEFAULT_AUTHORED_STATE,
-      interactiveState: data.interactiveState || DEFAULT_INTERACTIVE_STATE
+      authoredState: authoredState || DEFAULT_AUTHORED_STATE,
+      interactiveState: interactiveState || DEFAULT_INTERACTIVE_STATE
     });
     this.phone.post('supportedFeatures', {
       apiVersion: 1,
@@ -114,7 +116,7 @@ export default class App extends PureComponent {
           <Authoring initialAuthoredState={authoredState} initialInteractiveState={DEFAULT_INTERACTIVE_STATE}
                      onAuthoredStateChange={this.handleAuthoredStateChange}/>
         }
-        {mode === 'runtime' &&
+        {(mode === 'runtime' || mode === 'report') &&
           <Runtime authoredState={authoredState} initialInteractiveState={interactiveState}
                    onInteractiveStateChange={this.handleInteractiveStateChange}/>}
       </div>

--- a/js/components/runtime.js
+++ b/js/components/runtime.js
@@ -13,11 +13,13 @@ export default class Runtime extends PureComponent {
   }
 
   render() {
-    const { authoredState, initialInteractiveState } = this.props;
+    const { authoredState, initialInteractiveState, readOnly } = this.props;
     const { columns, labels, chartWidth, chartHeight } = authoredState;
     const { data } = initialInteractiveState;
+    // If `readOnly` property is set to true, overwrite `readOnly` property of the column definitions.
+    const columnsDef = readOnly ? columns.map(c => Object.assign({}, c, {readOnly: true})) : columns;
     return (
-      <TableAndCharts columns={columns} labels={labels} chartWidth={chartWidth} chartHeight={chartHeight}
+      <TableAndCharts columns={columnsDef} labels={labels} chartWidth={chartWidth} chartHeight={chartHeight}
                       initialData={data}
                       onDataChange={this.handleDataChange}/>
     )


### PR DESCRIPTION
This PR adds support of "report" mode. Table is read-only.
Also, there're some minor, backward compatible changes related to data passed to `initInteractive` call (state is parsed if it's a string).

This PR is related to https://github.com/concord-consortium/rigse/pull/303.