### PR TITLE
reduce padding around the interactive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: node_js
 node_js: node
 install:

--- a/css/app.less
+++ b/css/app.less
@@ -1,5 +1,5 @@
 body {
   font: 12px verdana, helvetica, sans-serif;
-  padding: 10px;
+  padding: 5px;
   background: #fff;
 }

--- a/css/authoring.less
+++ b/css/authoring.less
@@ -49,5 +49,6 @@
     width: 936px;
     border: 1px solid gray;
     border-radius: 5px;
+    padding: 10px;
   }
 }

--- a/css/table-and-charts.less
+++ b/css/table-and-charts.less
@@ -1,5 +1,4 @@
 .table-and-charts {
-  padding: 5px;
 
   .chart {
     display: inline-block;
@@ -8,7 +7,6 @@
   }
 
   .table {
-    margin: 10px 0 10px 10px;
     font-size: 14px;
   }
 }


### PR DESCRIPTION
I cut the overall padding down from 10px to 5px. And then I removed all other runtime padding and margins around the table.

In authoring there preview div adds a little padding so the table doesn't run right into the border of the preview area.

This is all to make it better using the table in the assessment block of lara where there is a lot of space. It seems these changes would be fine for the interactive box too since that provides some padding of its own.

https://models-resources.concord.org/table-interactive/branch/171005978-reduce-padding/index.html?mode=authoring

https://www.pivotaltracker.com/story/show/171005978